### PR TITLE
Joaomarra/hs 1195 as a client i want the select element to not shift in size

### DIFF
--- a/src/components/Select/index.vue
+++ b/src/components/Select/index.vue
@@ -92,6 +92,7 @@ const emit = defineEmits([
   'blur',
 ]);
 // const refSelectContainer = ref()
+const refSelect = ref();
 const refSelectInput = ref();
 
 const refSelectWrapper = ref();
@@ -298,25 +299,26 @@ function deselectAll() {
       <slot tag="div" name="prefix" />
     </div>
     <div
-      v-show="!open || !searchable"
-      ref="select"
-      class="flex h-full min-w-0 flex-1 flex-shrink items-center bg-transparent text-current outline-none"
+      ref="refSelect"
+      class="relative flex h-full min-w-0 flex-1 flex-shrink items-center bg-transparent text-current outline-none"
       :class="[$slots.prefix || condensed ? 'pl-2' : 'pl-3']"
       v-bind="$attrs"
     >
-      <div class="min-w-0 select-none truncate">
+      <div
+        :class="[!open || !searchable ? 'opacity-100' : 'opacity-0']"
+        class="min-w-0 select-none truncate"
+      >
         {{ getInputTitle() }}
       </div>
+      <input
+        v-if="open && searchable"
+        ref="refSelectInput"
+        v-model="search"
+        class="pointer-events-none absolute block h-full w-full min-w-0 select-none bg-transparent text-current outline-none"
+        :class="[$slots.prefix || condensed ? 'pl-2' : 'pl-3']"
+      />
     </div>
 
-    <input
-      v-if="open && searchable"
-      ref="refSelectInput"
-      v-model="search"
-      :size="1"
-      class="pointer-events-none block h-full min-w-0 flex-1 flex-shrink select-none bg-transparent text-current outline-none"
-      :class="[$slots.prefix || condensed ? 'pl-2' : 'pl-3']"
-    />
     <div
       class="pointer-events-none flex h-full flex-shrink-0 select-none items-center pr-3 text-gray-400 dark:text-gray-500"
       :class="[condensed ? 'pl-2' : 'pl-3']"

--- a/src/components/Select/index.vue
+++ b/src/components/Select/index.vue
@@ -92,7 +92,6 @@ const emit = defineEmits([
   'blur',
 ]);
 // const refSelectContainer = ref()
-const refSelect = ref();
 const refSelectInput = ref();
 
 const refSelectWrapper = ref();


### PR DESCRIPTION
Fixed the resizing of select input whenever it was searchable.
Now it's working like below:
![resizingSelect](https://github.com/hotellistat/robust-ui/assets/93348783/5c1cefce-5669-45be-b4dc-ad0ec3c9d804)
